### PR TITLE
Dns: Implement name compression algorithm when writing RRs.

### DIFF
--- a/src/Ward.Dns/Records/MailExchangerRecord.cs
+++ b/src/Ward.Dns/Records/MailExchangerRecord.cs
@@ -9,7 +9,7 @@ namespace Ward.Dns.Records
         public ushort Preference { get; }
         public string Hostname { get; }
 
-        public unsafe MailExchangerRecord (
+        internal unsafe MailExchangerRecord(
             string name,
             Dns.Type type,
             Class @class,
@@ -22,6 +22,17 @@ namespace Ward.Dns.Records
             Preference = SwapUInt16(BitConverter.ToUInt16(dataArray, 0));
             var _ = 2;
             Hostname = ParseComplexName(message, dataArray, ref _);
+        }
+
+        public MailExchangerRecord(
+            string name,
+            Class @class,
+            uint timeToLive,
+            ushort preference,
+            string hostname
+        ) : base(name, Type.MX, @class, timeToLive, 0, Array.Empty<byte>()) {
+            Preference = preference;
+            Hostname = hostname;
         }
 
         [System.Diagnostics.DebuggerStepThrough]

--- a/src/Ward.Dns/Utils.cs
+++ b/src/Ward.Dns/Utils.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -48,12 +49,42 @@ namespace Ward.Dns
             return nameBuilder.ToString();
         }
 
-        public static byte[] WriteQName(string name)
+        public static byte[] WriteQName(string name, Dictionary<string, ushort> offsetMap)
         {
-            var punycode = new IdnMapping().GetAscii(name);
-            var labels = punycode.Split('.');
-            var qname = new byte[labels.Sum(l => 1+l.Length) + 1];
+            if (string.IsNullOrWhiteSpace(name))
+                return new byte[] { 0 };
 
+            offsetMap = offsetMap ?? new Dictionary<string, ushort>();
+
+            // Convert the name to Punycode.
+            name = new IdnMapping().GetAscii(name);
+
+            // Find the longest name that's a suffix of this one
+            string longestSuffix = null;
+            foreach (var existingName in offsetMap.Keys) {
+                if (!name.EndsWith(existingName))
+                    continue;
+
+                if (existingName.Length > (longestSuffix?.Length ?? 0))
+                    longestSuffix = existingName;
+            }
+
+            // Strip the longest suffix from the end of the name.
+            name = name.Substring(0, name.Length - (longestSuffix?.Length ?? 0));
+            var offset = (ushort)(longestSuffix != null ? (0b1100_0000_0000_0000 | offsetMap[longestSuffix]) : 0);
+
+            var labels = name.Split(new [] { '.', }, StringSplitOptions.RemoveEmptyEntries);
+            var qnameLength = labels.Sum(l => 1+l.Length);
+
+            // If the offset is non-zero, append 2 bytes to the length of the labels.
+            // We'll write the ASCII labels, and then the 2 byte offset. If the offset is 0,
+            // we're writing the entire string, so we only need to add 1 byte to the length,
+            // for the null terminator.
+            qnameLength += offset == 0 ? 1 : 2;
+
+            var qname = new byte[qnameLength];
+
+            // Write any labels to the output.
             var pos = 0;
             foreach (var label in labels) {
                 qname[pos++] = (byte)label.Length;
@@ -65,6 +96,11 @@ namespace Ward.Dns
                     label.Length
                 );
                 pos += label.Length;
+            }
+
+            if (offset != 0) {
+                var offsetBytes = BitConverter.GetBytes(SwapUInt16(offset));
+                Buffer.BlockCopy(offsetBytes, 0, qname, pos, offsetBytes.Length);
             }
 
             return qname;

--- a/test/Ward.Dns.Tests/QNameTests.cs
+++ b/test/Ward.Dns.Tests/QNameTests.cs
@@ -1,3 +1,8 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using Ward.Dns.Records;
 using Xunit;
 
 namespace Ward.Dns.Tests
@@ -9,8 +14,74 @@ namespace Ward.Dns.Tests
         [InlineData("ssl.gstatic.com", new byte[] { 0x03, 0x73, 0x73, 0x6c, 0x07, 0x67, 0x73, 0x74, 0x61, 0x74, 0x69, 0x63, 0x03, 0x63, 0x6f, 0x6d, 0x00 })]
         public void Can_write_qname(string name, byte[] expectedQName)
         {
-            var qname = Utils.WriteQName(name);
+            var qname = Utils.WriteQName(name, null);
             Assert.Equal(expectedQName, qname);
+        }
+
+        [Fact]
+        public async Task Writes_recursive_names_correctly()
+        {
+            var headerFlags = new Header.HeaderFlags(false, false, false, true, true, false, false, false);
+            var header = new Header(0xaaaa, Opcode.Query, ReturnCode.NoError, headerFlags, 1, 1, 0, 0);
+            var question = new Question("google.com", Type.MX, Class.Internet);
+            var answers = new Record[] {
+                new MailExchangerRecord("google.com", Class.Internet, 600, 1, "aspmx.l.google.com"),
+                new MailExchangerRecord("google.com", Class.Internet, 600, 5, "alt1.aspmx.l.google.com")
+            };
+            var message = new Message(
+                header,
+                new [] { question },
+                answers,
+                Array.Empty<Record>(),
+                Array.Empty<Record>()
+            );
+            ReadOnlyMemory<byte> messageData = await MessageWriter.SerializeMessageAsync(message);
+
+            // Now we play the game of where are the answers that we want to check on...
+            // The header is 12 bytes, the question section is 16 bytes long
+            // (1 byte + 6 bytes of google + 1 byte + 3 bytes of com + null terminator
+            // + 4 bytes of type and class), so the first answer will be at 28 bytes.
+            Assert.Equal(new byte[] { 0xc0, 0x0c }, messageData.Slice(28, 2).ToArray());
+            // To get to where the next encoded name is, we add 2 bytes for the name we
+            // just checked, 8 bytes for the type, class, and TTL, 2 bytes for the data
+            // length, and 2 bytes for the MX preference, which means we should expect
+            // our next name at 42 bytes. We expect it should be 10 bytes long: 1 byte of
+            // length + 5 bytes for aspmx, 1 byte of length + 1 byte for l, and 2 bytes
+            // of offset to google.com earlier in the message.
+            Assert.Equal(
+                new byte[] { 0x05, (byte)'a', (byte)'s', (byte)'p', (byte)'m', (byte)'x', 0x01, (byte)'l', 0xc0, 0x0c },
+                messageData.Slice(42, 10).ToArray()
+            );
+            // The next encoded name is just after this, at the start of the next record,
+            // at 52 bytes. It should be again just a pointer to google.com at position 12.
+            Assert.Equal(new byte[] { 0xc0, 0x0c }, messageData.Slice(52, 2).ToArray());
+            // And following the same logic as before, we add 2+8+2+2 (14) bytes for the next
+            // name at 66 bytes. It should be 7 bytes long: 1 byte for length, 4 bytes for alt1,
+            // and a pointer to aspmx.l.google.com at byte 42.
+            Assert.Equal(
+                new byte[] { 0x04, (byte)'a', (byte)'l', (byte)'t', (byte)'1', 0xc0, 0x2a },
+                messageData.Slice(66, 7).ToArray()
+            );
+        }
+
+        [Fact]
+        public void Can_write_offset_qname()
+        {
+            var offsetMap = new Dictionary<string, ushort> {
+                ["aspmx.l.google.com"] = 12
+            };
+            var name = "alt4.aspmx.l.google.com";
+            var qname = Utils.WriteQName(name, offsetMap);
+
+            Assert.Equal(new byte [] {
+                0x04,
+                (byte)'a',
+                (byte)'l',
+                (byte)'t',
+                (byte)'4',
+                0xc0,
+                0x0c
+            }, qname);
         }
     }
 }

--- a/test/Ward.Dns.Tests/Ward.Dns.Tests.csproj
+++ b/test/Ward.Dns.Tests/Ward.Dns.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="xunit.assert.source" Version="2.3.1" />
     <PackageReference Include="Nett" Version="0.9.0" />
+    <PackageReference Include="System.Memory" Version="4.5.0-preview2-26406-04" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 


### PR DESCRIPTION
This compression algorithm is a trip. Basically, the message writer
needs to know when a QNAME needs to be written, because it needs to
look for the longest suffix that's already been written to the message
so that it can compress the name by only writing parts of the name
that have not before been seen in the message.

Fixes #1.