### PR TITLE
Hack in some thread safety for the TCP and UDP clients

### DIFF
--- a/src/Ward.DnsClient/HttpsDnsClient.cs
+++ b/src/Ward.DnsClient/HttpsDnsClient.cs
@@ -5,6 +5,7 @@ using System.Net.Http.Headers;
 using System.Net.Security;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Ward.Dns;
@@ -56,7 +57,7 @@ namespace Ward.DnsClient
             return policyErrors == SslPolicyErrors.None && cert.GetSpkiPinHash() == expectedSpkiPin;
         }
 
-        public async Task<IResolveResult> ResolveAsync(Question question)
+        public async Task<IResolveResult> ResolveAsync(Question question, CancellationToken cancellationToken = default)
         {
             var message = new Message(
                 new Header(
@@ -87,14 +88,14 @@ namespace Ward.DnsClient
             };
             msg.Headers.TryAddWithoutValidation("Accept", "application/dns-udpwireformat");
             msg.Headers.TryAddWithoutValidation("Host", tlsHost);
-            var response = await httpClient.SendAsync(msg);
+            var response = await httpClient.SendAsync(msg, cancellationToken);
             var content = await response.Content.ReadAsByteArrayAsync();
             var result = MessageParser.ParseMessage(content, 0);
 
             return new ResolveResult(result, content.Length);
         }
 
-        public Task<IResolveResult> ResolveAsync(string host, Type type, Class @class) =>
-            ResolveAsync(new Question(host, type, @class));
+        public Task<IResolveResult> ResolveAsync(string host, Type type, Class @class, CancellationToken cancellationToken = default) =>
+            ResolveAsync(new Question(host, type, @class), cancellationToken);
     }
 }

--- a/src/Ward.DnsClient/HttpsDnsClient.cs
+++ b/src/Ward.DnsClient/HttpsDnsClient.cs
@@ -14,6 +14,8 @@ namespace Ward.DnsClient
 {
     public class HttpsDnsClient : IDnsClient
     {
+        const int MaxConnections = 10;
+
         static readonly Version http20Version = new Version(2, 0);
 
         readonly IPAddress address;
@@ -31,11 +33,13 @@ namespace Ward.DnsClient
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
                 var handler = new WinHttpHandler();
+                handler.MaxConnectionsPerServer = MaxConnections;
                 if (!string.IsNullOrWhiteSpace(expectedSpkiPin))
                     handler.ServerCertificateValidationCallback = CheckServerCertificateMatchesExpectedHash;
                 httpClient = new HttpClient(handler);
             } else {
                 var handler = new HttpClientHandler();
+                handler.MaxConnectionsPerServer = MaxConnections;
                 if (!string.IsNullOrWhiteSpace(expectedSpkiPin))
                     handler.ServerCertificateCustomValidationCallback = CheckServerCertificateMatchesExpectedHash;
                 httpClient = new HttpClient(handler);

--- a/src/Ward.DnsClient/IDnsClient.cs
+++ b/src/Ward.DnsClient/IDnsClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 
 using Ward.Dns;
 
@@ -6,7 +7,7 @@ namespace Ward.DnsClient
 {
     public interface IDnsClient
     {
-        Task<IResolveResult> ResolveAsync(Question question);
-        Task<IResolveResult> ResolveAsync(string host, Type type, Class @class);
+        Task<IResolveResult> ResolveAsync(Question question, CancellationToken cancellationToken = default);
+        Task<IResolveResult> ResolveAsync(string host, Type type, Class @class, CancellationToken cancellationToken = default);
     }
 }

--- a/test/Ward.DnsClient.Tests/TcpClientTests.cs
+++ b/test/Ward.DnsClient.Tests/TcpClientTests.cs
@@ -85,5 +85,23 @@ namespace Ward.DnsClient.Tests
                 await client.ResolveAsync("example.com", Dns.Type.A, Class.Internet);
             });
         }
+
+        [Fact]
+        public async Task Multiple_threads_can_safely_query()
+        {
+            var client = new TcpDnsClient(IPAddress.Parse("1.1.1.1"), 853, true, "cloudflare-dns.com");
+            var tasks = new Task<IResolveResult>[5];
+            for (var i = 0; i < 5; i++)
+                tasks[i] = client.ResolveAsync("example.com", Dns.Type.A, Class.Internet);
+            var responses = await Task.WhenAll(tasks);
+
+            Assert.All(responses, resp => {
+                Assert.Collection(resp.Answers, answer => {
+                    Assert.Equal("example.com.", answer.Name);
+                    var a = Assert.IsType<AddressRecord>(answer);
+                    Assert.Equal("93.184.216.34", a.Address.ToString());
+                });
+            });
+        }
     }
 }


### PR DESCRIPTION
HTTP gets it "out of the box" by being a transactional protocol, but TCP and UDP do not (see #26). Do a hack for now with a semaphore controlling the access.