### PR TITLE
CI: Switch from Coveralls to Codecov for coverage reports

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,6 +3,7 @@ version: "{build}"
 configuration: Release
 environment:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+    RunCoverage: true
 install:
   - ps: choco install gitversion.portable -pre -y -r --no-progress
   - ps: choco install codecov -y -r --no-progress

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,7 +6,7 @@ environment:
     RunCoverage: true
 install:
   - ps: choco install gitversion.portable -pre -y -r --no-progress
-  - ps: choco install codecov -y -r --no-progress
+  - ps: choco install codecov -pre -y -r --no-progress --version 1.0.5
 before_build:
   - dotnet restore
   - ps: gitversion /output buildserver /updateAssemblyInfo

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,10 +13,8 @@ build:
     verbosity: minimal
 before_test:
   - ps: |
-      # Install OpenCover and ReportGenerator for coverage
+      # Install OpenCover
       nuget install -OutputDirectory packages -Version 4.6.519 OpenCover
-      nuget install -OutputDirectory packages -Version 3.1.2 ReportGenerator
-      nuget install -OutputDirectory packages -Version 0.8.0-beta0001 -Prerelease coveralls.net
 test_script:
   - ps: |
       # Run tests & coverage

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,11 +3,9 @@ version: "{build}"
 configuration: Release
 environment:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-    COVERALLS_REPO_TOKEN:
-        secure: tHVOzWM7nri9zj8uUeC9pkQbzF8HdMzjL6mVF/RC74OGko2GxyOfbCfTN1NOULlg
-    RunCoverage: "True"
 install:
   - ps: choco install gitversion.portable -pre -y -r --no-progress
+  - ps: choco install codecov -y -r --no-progress
 before_build:
   - dotnet restore
   - ps: gitversion /output buildserver /updateAssemblyInfo
@@ -27,26 +25,13 @@ test_script:
          -targetargs:"test" -output:"coverage.xml" -oldstyle `
          -filter:"+[Ward*]* -[Ward.DnsClient]Asn1.* -[Ward.*.Tests]*" `
          -excludebyattribute:*DebuggerStepThrough*
+      codecov -f "coverage.xml"
 after_test:
   - ps: |
       # Run some benchmarks
       Push-Location .\benchmarks\Ward.Benchmarks
       dotnet run -c Release -f net461 -- --attribute=RunInCI
       Pop-Location
-  - ps: |
-      # Generate coverage report
-      .\packages\ReportGenerator.3.1.2\tools\ReportGenerator.exe -reports:coverage.xml -targetdir:coverage
-  - ps: |
-      # Upload to Coveralls for non-PR builds. AppVeyor doesn't expose secret
-      # variables to PR builds.
-      if ($env:APPVEYOR_PULL_REQUEST_TITLE -eq $null) {
-        $coveralls = (Resolve-Path "packages\\coveralls.net.*\\tools\\csmacnz.coveralls.exe").ToString()
-        & $coveralls --opencover -i coverage.xml --repoToken $env:COVERALLS_REPO_TOKEN `
-          --commitId $env:APPVEYOR_REPO_COMMIT --commitBranch $env:APPVEYOR_REPO_BRANCH `
-          --commitAuthor $env:APPVEYOR_REPO_COMMIT_AUTHOR `
-          --commitEmail $env:APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL `
-          --commitMessage $env:APPVEYOR_REPO_COMMIT_MESSAGE --jobId $env:APPVEYOR_JOB_ID
-      }
   - dotnet msbuild /t:Restore,Pack /p:PackageOutputPath=artifacts /p:Version="%GitVersion_NuGetVersion%"
   - dotnet pack src\Ward.Console\Ward.Console.csproj /p:Version="%GitVersion_NuGetVersion%"
 artifacts:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,23 @@
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes
+  require_base: no        # [yes :: must have a base report to post]
+  require_head: yes       # [yes :: must have a head report to post]
+  branches: null
+coverage:
+  status:
+    project:
+      default:
+        # basic
+        target: auto
+        threshold: null
+        base: auto 
+        # advanced
+        branches: null
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: error
+        only_pulls: false
+        flags: null
+        paths: null

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Ward
 
-[![Coverage
-Status](https://coveralls.io/repos/github/bojanrajkovic/Ward/badge.svg?branch=master)](https://coveralls.io/github/bojanrajkovic/Ward?branch=master)
-[![Build status](https://ci.appveyor.com/api/projects/status/ikgme0cl837m3lar?svg=true)](https://ci.appveyor.com/project/bojanrajkovic/ward)
+[![codecov](https://codecov.io/gh/bojanrajkovic/Ward/branch/master/graph/badge.svg)](https://codecov.io/gh/bojanrajkovic/Ward)
+[![appveyor](https://ci.appveyor.com/api/projects/status/ikgme0cl837m3lar?svg=true)](https://ci.appveyor.com/project/bojanrajkovic/ward)
 
 A quixotic quest...stay tuned to this space.


### PR DESCRIPTION
Coveralls does not appear to be maintained very much anymore, Codecov seems much nicer
and has better support for PR builds.

Fixes #38, fixes #17.