### PR TITLE
Improve parsing performance

### DIFF
--- a/benchmarks/Ward.Benchmarks/Config.cs
+++ b/benchmarks/Ward.Benchmarks/Config.cs
@@ -1,5 +1,5 @@
-using System;
 using System.Runtime.InteropServices;
+
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Environments;
@@ -15,17 +15,8 @@ namespace Ward.Benchmarks
             var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
             Add(Job.Default.With(CsProjCoreToolchain.NetCoreApp21));
-
-            if (isWindows)
-                Add(Job.Default.With(CsProjClassicNetToolchain.Net461));
-            else
-                Add(Job.Default.With(Runtime.Mono));
-
+            Add(isWindows ? Job.Default.With(CsProjClassicNetToolchain.Net461) : Job.Default.With(Runtime.Mono));
             Add(MemoryDiagnoser.Default);
-
-            // If we're not in Appveyor, add hardware counters.
-            if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("APPVEYOR")) && isWindows)
-                Add(HardwareCounter.BranchMispredictions, HardwareCounter.BranchInstructions, HardwareCounter.CacheMisses);
         }
     }
 }

--- a/benchmarks/Ward.Benchmarks/MessageParseBenchmark.cs
+++ b/benchmarks/Ward.Benchmarks/MessageParseBenchmark.cs
@@ -1,9 +1,4 @@
-using System;
-using System.IO;
-
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Attributes.Jobs;
-using BenchmarkDotNet.Diagnosers;
 using Ward.Dns;
 using Ward.Tests.Core;
 
@@ -25,7 +20,7 @@ namespace Ward.Benchmarks
         [Benchmark]
         public int ParseMessage()
         {
-            var message = MessageParser.ParseMessage(messageData, 0);
+            var message = MessageParser.ParseMessage(messageData);
             return message.Header.TotalQuestions;
         }
     }

--- a/src/Ward.Dns/Message.cs
+++ b/src/Ward.Dns/Message.cs
@@ -21,25 +21,25 @@ namespace Ward.Dns
         /// Gets the list of questions in this message.
         /// </summary>
         /// <returns>The list of questions in this message.</returns>
-        public ImmutableList<Question> Questions { get; }
+        public IReadOnlyList<Question> Questions { get; }
 
         /// <summary>
         /// Gets the list of answers in this message.
         /// </summary>
         /// <returns>The list of answers in this message.</returns>
-        public ImmutableList<Record> Answers { get; }
+        public IReadOnlyList<Record> Answers { get; }
 
         /// <summary>
         /// Gets the list of entries in the authority section of this message.
         /// </summary>
         /// <returns>The entries in the authority section of the message.</returns>
-        public ImmutableList<Record> Authority { get; }
+        public IReadOnlyList<Record> Authority { get; }
 
         /// <summary>
         /// Gets the list of entries in the additional section of this message.
         /// </summary>
         /// <returns>The entries in the additional section of this message.</returns>
-        public ImmutableList<Record> Additional { get; }
+        public IReadOnlyList<Record> Additional { get; }
 
         /// <summary>
         /// Creates a new DNS message.
@@ -51,16 +51,16 @@ namespace Ward.Dns
         /// <param name="additional">The additional entries to include in the message.</param>
         public Message(
             Header header,
-            IEnumerable<Question> questions,
-            IEnumerable<Record> answers,
-            IEnumerable<Record> authority,
-            IEnumerable<Record> additional
+            IReadOnlyList<Question> questions,
+            IReadOnlyList<Record> answers,
+            IReadOnlyList<Record> authority,
+            IReadOnlyList<Record> additional
         ) {
             Header = header;
-            Questions = questions.ToImmutableList();
-            Answers = answers.ToImmutableList();
-            Authority = authority.ToImmutableList();
-            Additional = additional.ToImmutableList();
+            Questions = questions;
+            Answers = answers;
+            Authority = authority;
+            Additional = additional;
         }
     }
 }

--- a/src/Ward.Dns/Records/CnameRecord.cs
+++ b/src/Ward.Dns/Records/CnameRecord.cs
@@ -1,5 +1,5 @@
 using System;
-
+using System.Collections.Generic;
 using static Ward.Dns.Utils;
 
 namespace Ward.Dns.Records
@@ -27,6 +27,7 @@ namespace Ward.Dns.Records
         /// <param name="length">The length of the resource record data.</param>
         /// <param name="data">The resource record-specific data.</param>
         /// <param name="message">The complete original message.</param>
+        /// <param name="reverseOffsetMap">The reverse offset map.</param>
         /// <remarks>
         /// Only used from internal parsing code.
         /// </remarks>
@@ -36,11 +37,12 @@ namespace Ward.Dns.Records
             uint timeToLive,
             ushort length,
             ReadOnlyMemory<byte> data,
-            byte[] message
+            ReadOnlySpan<byte> message,
+            Dictionary<int, string> reverseOffsetMap
         ) : base(name, Type.CNAME, @class, timeToLive, length, data)
         {
             var _ = 0;
-            Hostname = ParseComplexName(message, data.ToArray(), ref _);
+            Hostname = ParseComplexName(message, data.Span, ref _, reverseOffsetMap);
         }
 
         /// <summary>

--- a/src/Ward.Dns/Records/MailExchangerRecord.cs
+++ b/src/Ward.Dns/Records/MailExchangerRecord.cs
@@ -1,5 +1,6 @@
 using System;
 
+using System.Buffers.Binary;
 using static Ward.Dns.Utils;
 
 namespace Ward.Dns.Records
@@ -50,7 +51,7 @@ namespace Ward.Dns.Records
             byte[] message
         ) : base(name, Type.MX, @class, timeToLive, length, data) {
             var dataArray = data.ToArray();
-            Preference = SwapUInt16(BitConverter.ToUInt16(dataArray, 0));
+            Preference = BinaryPrimitives.ReadUInt16BigEndian(data.Span);
             var _ = 2;
             Hostname = ParseComplexName(message, dataArray, ref _);
         }

--- a/src/Ward.Dns/Records/MailExchangerRecord.cs
+++ b/src/Ward.Dns/Records/MailExchangerRecord.cs
@@ -1,6 +1,6 @@
 using System;
-
 using System.Buffers.Binary;
+using System.Collections.Generic;
 using static Ward.Dns.Utils;
 
 namespace Ward.Dns.Records
@@ -39,6 +39,7 @@ namespace Ward.Dns.Records
         /// <param name="length">The length of the resource record data.</param>
         /// <param name="data">The resource record-specific data.</param>
         /// <param name="message">The complete original message.</param>
+        /// <param name="reverseOffsetMap">The reverse offset map.</param>
         /// <remarks>
         /// Only used from internal parsing code.
         /// </remarks>
@@ -48,12 +49,13 @@ namespace Ward.Dns.Records
             uint timeToLive,
             ushort length,
             ReadOnlyMemory<byte> data,
-            byte[] message
-        ) : base(name, Type.MX, @class, timeToLive, length, data) {
-            var dataArray = data.ToArray();
+            ReadOnlySpan<byte> message,
+            Dictionary<int, string> reverseOffsetMap
+        ) : base(name, Type.MX, @class, timeToLive, length, data)
+        {
             Preference = BinaryPrimitives.ReadUInt16BigEndian(data.Span);
             var _ = 2;
-            Hostname = ParseComplexName(message, dataArray, ref _);
+            Hostname = ParseComplexName(message, data.Span, ref _, reverseOffsetMap);
         }
 
         /// <summary>

--- a/src/Ward.Dns/Records/NsRecord.cs
+++ b/src/Ward.Dns/Records/NsRecord.cs
@@ -1,5 +1,5 @@
 using System;
-
+using System.Collections.Generic;
 using static Ward.Dns.Utils;
 
 namespace Ward.Dns.Records
@@ -29,6 +29,7 @@ namespace Ward.Dns.Records
         /// <param name="length">The length of the resource record data.</param>
         /// <param name="data">The resource record-specific data.</param>
         /// <param name="message">The complete original message.</param>
+        /// <param name="reverseOffsetMap">The reverse offset map.</param>
         /// <remarks>
         /// Only used from internal parsing code.
         /// </remarks>
@@ -38,10 +39,11 @@ namespace Ward.Dns.Records
             uint timeToLive,
             ushort length,
             ReadOnlyMemory<byte> data,
-            byte[] message
+            ReadOnlySpan<byte> message,
+            Dictionary<int, string> reverseOffsetMap
         ) : base(name, Type.NS, @class, timeToLive, length, data) {
             var _ = 0;
-            Hostname = ParseComplexName(message, data.ToArray(), ref _);
+            Hostname = ParseComplexName(message, data.Span, ref _, reverseOffsetMap);
         }
 
         /// <summary>

--- a/src/Ward.Dns/Records/PtrRecord.cs
+++ b/src/Ward.Dns/Records/PtrRecord.cs
@@ -1,5 +1,5 @@
 using System;
-
+using System.Collections.Generic;
 using static Ward.Dns.Utils;
 
 namespace Ward.Dns.Records
@@ -27,6 +27,7 @@ namespace Ward.Dns.Records
         /// <param name="length">The length of the resource record data.</param>
         /// <param name="data">The resource record-specific data.</param>
         /// <param name="message">The complete original message.</param>
+        /// <param name="reverseOffsetMap">The reverse offset map.</param>
         /// <remarks>
         /// Only used from internal parsing code.
         /// </remarks>
@@ -36,10 +37,11 @@ namespace Ward.Dns.Records
             uint timeToLive,
             ushort length,
             ReadOnlyMemory<byte> data,
-            byte[] message
+            ReadOnlySpan<byte> message,
+            Dictionary<int, string> reverseOffsetMap
         ) : base(name, Type.PTR, @class, timeToLive, length, data) {
             var _ = 0;
-            Hostname = ParseComplexName(message, data.ToArray(), ref _);
+            Hostname = ParseComplexName(message, data.Span, ref _, reverseOffsetMap);
         }
 
         /// <summary>

--- a/src/Ward.Dns/Records/RecordFactory.cs
+++ b/src/Ward.Dns/Records/RecordFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Ward.Dns.Records
 {
@@ -11,24 +12,25 @@ namespace Ward.Dns.Records
             uint ttl,
             ushort length,
             ReadOnlyMemory<byte> data,
-            byte[] message
+            ReadOnlySpan<byte> message,
+            Dictionary<int, string> reverseOffsetMap
         ) {
             switch (type) {
                 case Type.A:
                 case Type.AAAA:
                     return new AddressRecord(name, type, @class, ttl, length, data);
                 case Type.MX:
-                    return new MailExchangerRecord(name, @class, ttl, length, data, message);
+                    return new MailExchangerRecord(name, @class, ttl, length, data, message, reverseOffsetMap);
                 case Type.CAA:
                     return new CaaRecord(name, @class, ttl, length, data);
                 case Type.CNAME:
-                    return new CnameRecord(name, @class, ttl, length, data, message);
+                    return new CnameRecord(name, @class, ttl, length, data, message, reverseOffsetMap);
                 case Type.NS:
-                    return new NsRecord(name, @class, ttl, length, data, message);
+                    return new NsRecord(name, @class, ttl, length, data, message, reverseOffsetMap);
                 case Type.SOA:
-                    return new SoaRecord(name, @class, ttl, length, data, message);
+                    return new SoaRecord(name, @class, ttl, length, data, message, reverseOffsetMap);
                 case Type.PTR:
-                    return new PtrRecord(name, @class, ttl, length, data, message);
+                    return new PtrRecord(name, @class, ttl, length, data, message, reverseOffsetMap);
                 case Type.TXT:
                     return new TxtRecord(name, @class, ttl, length, data);
                 case Type.OPT:

--- a/src/Ward.Dns/Records/SoaRecord.cs
+++ b/src/Ward.Dns/Records/SoaRecord.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net;
+using static System.Buffers.Binary.BinaryPrimitives;
 
 namespace Ward.Dns.Records
 {
@@ -89,7 +90,7 @@ namespace Ward.Dns.Records
             uint timeToLive,
             ushort length,
             ReadOnlyMemory<byte> data,
-            byte[] message
+            ReadOnlySpan<byte> message,
         ) : base(name, Type.SOA, @class, timeToLive, length, data) {
             var dataArray = data.ToArray();
             var offset = 0;
@@ -100,6 +101,11 @@ namespace Ward.Dns.Records
             Retry = IPAddress.NetworkToHostOrder(BitConverter.ToInt32(dataArray, offset + 8));
             Expire = IPAddress.NetworkToHostOrder(BitConverter.ToInt32(dataArray, offset + 12));
             MinimumTtl = Utils.SwapUInt32(BitConverter.ToUInt32(dataArray, offset + 16));
+            Serial = ReadUInt32BigEndian(data.Slice(offset, 4).Span);
+            Refresh = ReadInt32BigEndian(data.Slice(offset + 4, 4).Span);
+            Retry = ReadInt32BigEndian(data.Slice(offset + 8, 4).Span);
+            Expire = ReadInt32BigEndian(data.Slice(offset + 12, 4).Span);
+            MinimumTtl = ReadUInt32BigEndian(data.Slice(offset + 16, 4).Span);
         }
 
         /// <summary>

--- a/src/Ward.Dns/Records/SoaRecord.cs
+++ b/src/Ward.Dns/Records/SoaRecord.cs
@@ -1,5 +1,6 @@
 using System;
-using System.Net;
+using System.Collections.Generic;
+
 using static System.Buffers.Binary.BinaryPrimitives;
 
 namespace Ward.Dns.Records
@@ -81,6 +82,13 @@ namespace Ward.Dns.Records
         /// <summary>
         /// Creates a SOA record.
         /// </summary>
+        /// <param name="name">The owner-name or label to which this record belongs.</param>
+        /// <param name="class">The resource record class.</param>
+        /// <param name="timeToLive">The resource record time to live.</param>
+        /// <param name="length">The length of the resource record data.</param>
+        /// <param name="data">The resource record-specific data.</param>
+        /// <param name="message">The complete original message.</param>
+        /// <param name="reverseOffsetMap">The reverse offset map.</param>
         /// <remarks>
         /// Only used from internal parsing code.
         /// </remarks>
@@ -91,16 +99,12 @@ namespace Ward.Dns.Records
             ushort length,
             ReadOnlyMemory<byte> data,
             ReadOnlySpan<byte> message,
+            Dictionary<int, string> reverseOffsetMap
         ) : base(name, Type.SOA, @class, timeToLive, length, data) {
-            var dataArray = data.ToArray();
             var offset = 0;
-            PrimaryNameServer = Utils.ParseComplexName(message, dataArray, ref offset);
-            ResponsibleName = Utils.ParseComplexName(message, dataArray, ref offset);
-            Serial = Utils.SwapUInt32(BitConverter.ToUInt32(dataArray, offset));
-            Refresh = IPAddress.NetworkToHostOrder(BitConverter.ToInt32(dataArray, offset + 4));
-            Retry = IPAddress.NetworkToHostOrder(BitConverter.ToInt32(dataArray, offset + 8));
-            Expire = IPAddress.NetworkToHostOrder(BitConverter.ToInt32(dataArray, offset + 12));
-            MinimumTtl = Utils.SwapUInt32(BitConverter.ToUInt32(dataArray, offset + 16));
+            PrimaryNameServer = Utils.ParseComplexName(message, data.Span, ref offset, reverseOffsetMap);
+            ResponsibleName = Utils.ParseComplexName(message, data.Span, ref offset, reverseOffsetMap);
+
             Serial = ReadUInt32BigEndian(data.Slice(offset, 4).Span);
             Refresh = ReadInt32BigEndian(data.Slice(offset + 4, 4).Span);
             Retry = ReadInt32BigEndian(data.Slice(offset + 8, 4).Span);

--- a/src/Ward.Dns/StringUtilities.cs
+++ b/src/Ward.Dns/StringUtilities.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
+{
+    internal static class StringUtilities
+    {
+        public static unsafe void TryGetAsciiString(byte* input, char* output, int count)
+        {
+            // Calculate end position
+            var end = input + count;
+
+            do {
+                // If Vector not-accelerated or remaining less than vector size
+                if (!Vector.IsHardwareAccelerated || input > end - Vector<sbyte>.Count) {
+                    if (IntPtr.Size == 8) // Use Intrinsic switch for branch elimination
+                    {
+                        // 64-bit: Loop longs by default
+                        while (input <= end - sizeof(long)) {
+
+                            output[0] = (char)input[0];
+                            output[1] = (char)input[1];
+                            output[2] = (char)input[2];
+                            output[3] = (char)input[3];
+                            output[4] = (char)input[4];
+                            output[5] = (char)input[5];
+                            output[6] = (char)input[6];
+                            output[7] = (char)input[7];
+
+                            input += sizeof(long);
+                            output += sizeof(long);
+                        }
+                        if (input <= end - sizeof(int)) {
+
+                            output[0] = (char)input[0];
+                            output[1] = (char)input[1];
+                            output[2] = (char)input[2];
+                            output[3] = (char)input[3];
+
+                            input += sizeof(int);
+                            output += sizeof(int);
+                        }
+                    } else {
+                        // 32-bit: Loop ints by default
+                        while (input <= end - sizeof(int)) {
+
+                            output[0] = (char)input[0];
+                            output[1] = (char)input[1];
+                            output[2] = (char)input[2];
+                            output[3] = (char)input[3];
+
+                            input += sizeof(int);
+                            output += sizeof(int);
+                        }
+                    }
+                    if (input <= end - sizeof(short)) {
+
+                        output[0] = (char)input[0];
+                        output[1] = (char)input[1];
+
+                        input += sizeof(short);
+                        output += sizeof(short);
+                    }
+                    if (input < end) {
+                        output[0] = (char)input[0];
+                    }
+
+                    return;
+                }
+
+                // do/while as entry condition already checked
+                do {
+                    var vector = Unsafe.AsRef<Vector<sbyte>>(input);
+                    Vector.Widen(
+                        vector,
+                        out Unsafe.AsRef<Vector<short>>(output),
+                        out Unsafe.AsRef<Vector<short>>(output + Vector<short>.Count));
+
+                    input += Vector<sbyte>.Count;
+                    output += Vector<sbyte>.Count;
+                } while (input <= end - Vector<sbyte>.Count);
+
+                // Vector path done, loop back to do non-Vector
+                // If is a exact multiple of vector size, bail now
+            } while (input < end);
+        }
+    }
+}

--- a/src/Ward.Dns/Ward.Dns.csproj
+++ b/src/Ward.Dns/Ward.Dns.csproj
@@ -14,5 +14,7 @@
   <ItemGroup Label="NuGet Packages">
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.Memory" Version="4.5.1" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.1" />
   </ItemGroup>
 </Project>

--- a/src/Ward.DnsClient/IResolveResult.cs
+++ b/src/Ward.DnsClient/IResolveResult.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Collections.Immutable;
 
 using Ward.Dns;
@@ -31,7 +32,7 @@ namespace Ward.DnsClient
         /// <value>
         /// The answers.
         /// </value>
-        ImmutableList<Record> Answers { get; }
+        IReadOnlyList<Record> Answers { get; }
 
         /// <summary>
         /// Gets the authoritative servers.
@@ -39,7 +40,7 @@ namespace Ward.DnsClient
         /// <value>
         /// The authoritative servers.
         /// </value>
-        ImmutableList<Record> Authority { get; }
+        IReadOnlyList<Record> Authority { get; }
 
         /// <summary>
         /// Gets the additional records.
@@ -47,7 +48,7 @@ namespace Ward.DnsClient
         /// <value>
         /// The additional records.
         /// </value>
-        ImmutableList<Record> Additional { get; }
+        IReadOnlyList<Record> Additional { get; }
 
         /// <summary>
         /// Gets the questions.
@@ -55,6 +56,6 @@ namespace Ward.DnsClient
         /// <value>
         /// The questions.
         /// </value>
-        ImmutableList<Question> Questions { get; }
+        IReadOnlyList<Question> Questions { get; }
     }
 }

--- a/src/Ward.DnsClient/ResolveResult.cs
+++ b/src/Ward.DnsClient/ResolveResult.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Collections.Immutable;
 
 using Ward.Dns;
@@ -19,16 +20,16 @@ namespace Ward.DnsClient
         public Header Header => message.Header;
 
         /// <inheritdoc />
-        public ImmutableList<Record> Answers => message.Answers;
+        public IReadOnlyList<Record> Answers => message.Answers;
 
         /// <inheritdoc />
-        public ImmutableList<Record> Authority => message.Authority;
+        public IReadOnlyList<Record> Authority => message.Authority;
 
         /// <inheritdoc />
-        public ImmutableList<Record> Additional => message.Additional;
+        public IReadOnlyList<Record> Additional => message.Additional;
 
         /// <inheritdoc />
-        public ImmutableList<Question> Questions => message.Questions;
+        public IReadOnlyList<Question> Questions => message.Questions;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ResolveResult"/> class.

--- a/test/Ward.Dns.Tests/Assertions.cs
+++ b/test/Ward.Dns.Tests/Assertions.cs
@@ -26,25 +26,25 @@ namespace Xunit
     {
         public static void Question(TomlTable expectedQuestion, Question question)
         {
-            Assert.Equal(expectedQuestion.Get<string>("name"), question.Name);
-            Assert.Equal(expectedQuestion.Get<Class>("class"), question.Class);
-            Assert.Equal(expectedQuestion.Get<Ward.Dns.Type>("type"), question.Type);
+            Equal(expectedQuestion.Get<string>("name"), question.Name);
+            Equal(expectedQuestion.Get<Class>("class"), question.Class);
+            Equal(expectedQuestion.Get<Ward.Dns.Type>("type"), question.Type);
         }
 
         public static void Record(TomlTable expectedRecord, Ward.Dns.Record record)
         {
-            Assert.Equal(expectedRecord.TryGetValue("name")?.Get<string>(), record.Name);
-            Assert.Equal(expectedRecord.Get<Ward.Dns.Type>("type"), record.Type);
+            Equal(expectedRecord.TryGetValue("name")?.Get<string>(), record.Name);
+            Equal(expectedRecord.Get<Ward.Dns.Type>("type"), record.Type);
 
             var @class = expectedRecord.Get("class");
             if (@class.TomlType == TomlObjectType.Int)
-                Assert.Equal((Class)(@class.Get<int>()), record.Class);
+                Equal((Class)(@class.Get<int>()), record.Class);
             else
-                Assert.Equal(@class.Get<Class>(), record.Class);
+                Equal(@class.Get<Class>(), record.Class);
 
-            Assert.Equal(expectedRecord.Get<uint>("ttl"), record.TimeToLive);
-            Assert.Equal(expectedRecord.Get<ushort>("length"), record.Length);
-            Assert.Equal(
+            Equal(expectedRecord.Get<uint>("ttl"), record.TimeToLive);
+            Equal(expectedRecord.Get<ushort>("length"), record.Length);
+            Equal(
                 expectedRecord.Get<string>("data"),
                 record.Data.ToArray().Aggregate(string.Empty, (s, v) => {
                     return s += v.ToString("X2").ToLower();
@@ -77,27 +77,27 @@ namespace Xunit
                     Assert.NSRecord(expectedRecord, (NsRecord)record);
                     break;
                 case Ward.Dns.Type.OPT:
-                    Assert.OPTRecord(expectedRecord, (OptRecord)record);
+                    OPTRecord(expectedRecord, (OptRecord)record);
                     break;
             }
         }
 
         public static void OPTRecord(TomlTable expectedRecord, OptRecord record)
         {
-            Assert.Equal(expectedRecord.Get<ushort>("udpPayload"), record.UdpPayloadSize);
-            Assert.Equal(expectedRecord.Get<byte>("extendedRcode"), record.ExtendedRcode);
-            Assert.Equal(expectedRecord.Get<byte>("version"), record.Edns0Version);
-            Assert.Equal(expectedRecord.Get<bool>("dnsSecOK"), record.DnsSecOk);
+            Equal(expectedRecord.Get<ushort>("udpPayload"), record.UdpPayloadSize);
+            Equal(expectedRecord.Get<byte>("extendedRcode"), record.ExtendedRcode);
+            Equal(expectedRecord.Get<byte>("version"), record.Edns0Version);
+            Equal(expectedRecord.Get<bool>("dnsSecOK"), record.DnsSecOk);
 
             if (expectedRecord.ContainsKey("optionalData")) {
                 var optionalData = expectedRecord.Get<TomlTableArray>("optionalData");
-                Assert.Equal(optionalData.Items.Count, record.OptionalData.Count());
+                Equal(optionalData.Items.Count, record.OptionalData.Count());
                 var recordData = (IList<(OptRecord.OptionCode optionCode, ReadOnlyMemory<byte> optionalData)>)record.OptionalData;
                 recordData.ForEach((val, idx) => {
                     var expectedData = optionalData.Items[idx];
-                    Assert.Equal(expectedData.Get<OptRecord.OptionCode>("optionCode"), val.optionCode);
-                    Assert.Equal(expectedData.Get<int>("dataLength"), val.optionalData.Length);
-                    Assert.Equal(
+                    Equal(expectedData.Get<OptRecord.OptionCode>("optionCode"), val.optionCode);
+                    Equal(expectedData.Get<int>("dataLength"), val.optionalData.Length);
+                    Equal(
                         expectedData.Get<string>("data"),
                         val.optionalData.ToArray().Aggregate(string.Empty, (s, v) => {
                             return s += v.ToString("X2").ToLower();
@@ -109,75 +109,75 @@ namespace Xunit
 
         public static void NSRecord(TomlTable expectedRecord, NsRecord record)
         {
-            Assert.Equal(expectedRecord.Get<string>("hostname"), record.Hostname);
+            Equal(expectedRecord.Get<string>("hostname"), record.Hostname);
         }
 
         public static void PTRRecord(TomlTable expectedRecord, PtrRecord record)
         {
-            Assert.Equal(expectedRecord.Get<string>("hostname"), record.Hostname);
+            Equal(expectedRecord.Get<string>("hostname"), record.Hostname);
         }
 
         public static void TXTRecord(TomlTable expectedRecord, TxtRecord record)
         {
-            Assert.Equal(expectedRecord.Get<string>("value"), record.TextData);
+            Equal(expectedRecord.Get<string>("value"), record.TextData);
         }
 
         public static void CNAMERecord(TomlTable expectedRecord, CnameRecord record)
         {
-            Assert.Equal(expectedRecord.Get<string>("hostname"), record.Hostname);
+            Equal(expectedRecord.Get<string>("hostname"), record.Hostname);
         }
 
         public static void CAARecord(TomlTable expectedRecord, CaaRecord record)
         {
-            Assert.Equal(expectedRecord.Get<bool>("critical"), record.Critical);
-            Assert.Equal(expectedRecord.Get<string>("tag"), record.Tag);
-            Assert.Equal(expectedRecord.Get<string>("value"), record.Value);
+            Equal(expectedRecord.Get<bool>("critical"), record.Critical);
+            Equal(expectedRecord.Get<string>("tag"), record.Tag);
+            Equal(expectedRecord.Get<string>("value"), record.Value);
         }
 
         public static void SOARecord(TomlTable expectedRecord, SoaRecord record)
         {
-            Assert.Equal(expectedRecord.Get<string>("primary"), record.PrimaryNameServer);
-            Assert.Equal(expectedRecord.Get<string>("responsible"), record.ResponsibleName);
-            Assert.Equal(expectedRecord.Get<uint>("serial"), record.Serial);
-            Assert.Equal(expectedRecord.Get<int>("refresh"), record.Refresh);
-            Assert.Equal(expectedRecord.Get<int>("retry"), record.Retry);
-            Assert.Equal(expectedRecord.Get<int>("expire"), record.Expire);
-            Assert.Equal(expectedRecord.Get<uint>("minimum"), record.MinimumTtl);
+            Equal(expectedRecord.Get<string>("primary"), record.PrimaryNameServer);
+            Equal(expectedRecord.Get<string>("responsible"), record.ResponsibleName);
+            Equal(expectedRecord.Get<uint>("serial"), record.Serial);
+            Equal(expectedRecord.Get<int>("refresh"), record.Refresh);
+            Equal(expectedRecord.Get<int>("retry"), record.Retry);
+            Equal(expectedRecord.Get<int>("expire"), record.Expire);
+            Equal(expectedRecord.Get<uint>("minimum"), record.MinimumTtl);
         }
 
         public static void MXRecord(TomlTable expectedRecord, MailExchangerRecord record)
         {
-            Assert.Equal(expectedRecord.Get<int>("preference"), record.Preference);
-            Assert.Equal(expectedRecord.Get<string>("hostname"), record.Hostname);
+            Equal(expectedRecord.Get<int>("preference"), record.Preference);
+            Equal(expectedRecord.Get<string>("hostname"), record.Hostname);
         }
 
         public static void ARecord(TomlTable expectedRecord, AddressRecord record)
         {
-            Assert.Equal(expectedRecord.Get<string>("address"), record.Address.ToString());
+            Equal(expectedRecord.Get<string>("address"), record.Address.ToString());
         }
 
         public static void HeaderFlags(TomlTable expectedHeader, Header.HeaderFlags flags)
         {
-            Assert.Equal(expectedHeader.Get<bool>("query"), flags.Query);
-            Assert.Equal(expectedHeader.Get<bool>("authoritative"), flags.Authoritative);
-            Assert.Equal(expectedHeader.Get<bool>("truncated"), flags.Truncated);
-            Assert.Equal(expectedHeader.Get<bool>("recurse"), flags.Recurse);
-            Assert.Equal(expectedHeader.Get<bool>("recursionAvailable"), flags.RecursionAvailable);
-            Assert.Equal(expectedHeader.Get<bool>("z"), flags.Z);
-            Assert.Equal(expectedHeader.Get<bool>("authenticated"), flags.Authenticated);
-            Assert.Equal(expectedHeader.Get<bool>("checkingDisabled"), flags.CheckingDisabled);
+            Equal(expectedHeader.Get<bool>("query"), flags.Query);
+            Equal(expectedHeader.Get<bool>("authoritative"), flags.Authoritative);
+            Equal(expectedHeader.Get<bool>("truncated"), flags.Truncated);
+            Equal(expectedHeader.Get<bool>("recurse"), flags.Recurse);
+            Equal(expectedHeader.Get<bool>("recursionAvailable"), flags.RecursionAvailable);
+            Equal(expectedHeader.Get<bool>("z"), flags.Z);
+            Equal(expectedHeader.Get<bool>("authenticated"), flags.Authenticated);
+            Equal(expectedHeader.Get<bool>("checkingDisabled"), flags.CheckingDisabled);
         }
 
         public static void Header(TomlTable expectedHeader, Header header)
         {
-            Assert.Equal(expectedHeader.Get<ushort>("id"), header.Id);
-            Assert.Equal(expectedHeader.Get<Opcode>("opcode"), header.Opcode);
-            Assert.Equal(expectedHeader.Get<ReturnCode>("returnCode"), header.ReturnCode);
+            Equal(expectedHeader.Get<ushort>("id"), header.Id);
+            Equal(expectedHeader.Get<Opcode>("opcode"), header.Opcode);
+            Equal(expectedHeader.Get<ReturnCode>("returnCode"), header.ReturnCode);
             Assert.HeaderFlags(expectedHeader, header.Flags);
-            Assert.Equal(expectedHeader.Get<int>("questions"), header.TotalQuestions);
-            Assert.Equal(expectedHeader.Get<int>("answers"), header.TotalAnswerRecords);
-            Assert.Equal(expectedHeader.Get<int>("authority"), header.TotalAuthorityRecords);
-            Assert.Equal(expectedHeader.Get<int>("additional"), header.TotalAdditionalRecords);
+            Equal(expectedHeader.Get<int>("questions"), header.TotalQuestions);
+            Equal(expectedHeader.Get<int>("answers"), header.TotalAnswerRecords);
+            Equal(expectedHeader.Get<int>("authority"), header.TotalAuthorityRecords);
+            Equal(expectedHeader.Get<int>("additional"), header.TotalAdditionalRecords);
         }
     }
 }

--- a/test/Ward.Dns.Tests/MessageTests.cs
+++ b/test/Ward.Dns.Tests/MessageTests.cs
@@ -61,17 +61,10 @@ namespace Ward.Dns.Tests
             Assert.Equal(expectedAuthorities?.Count ?? 0, message.Header.TotalAuthorityRecords);
             Assert.Equal(expectedAdditional?.Count ?? 0, message.Header.TotalAdditionalRecords);
 
-            if (expectedQuestions != null)
-                expectedQuestions.Items.ForEach((eq, idx) => Assert.Question(eq, message.Questions[idx]));
-
-            if (expectedAnswers != null)
-                expectedAnswers.Items.ForEach((er, idx) => Assert.Record(er, message.Answers[idx]));
-
-            if (expectedAuthorities != null)
-                expectedAuthorities.Items.ForEach((ea, idx) => Assert.Record(ea, message.Authority[idx]));
-
-            if (expectedAdditional != null)
-                expectedAdditional.Items.ForEach((ea, idx) => Assert.Record(ea, message.Additional[idx]));
+            expectedQuestions.Items.ForEach((eq, idx) => Assert.Question(eq, message.Questions[idx]));
+            expectedAnswers?.Items.ForEach((er, idx) => Assert.Record(er, message.Answers[idx]));
+            expectedAuthorities?.Items.ForEach((ea, idx) => Assert.Record(ea, message.Authority[idx]));
+            expectedAdditional?.Items.ForEach((ea, idx) => Assert.Record(ea, message.Additional[idx]));
         }
     }
 }

--- a/test/Ward.Dns.Tests/MessageWriterTests.cs
+++ b/test/Ward.Dns.Tests/MessageWriterTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers.Binary;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -41,7 +42,7 @@ namespace Ward.Dns.Tests
 
             // But if we inspect the bytes, we should find that only the 2nd and 3rd are set
             // in the actual header RCODE field.
-            var flagsBitfield = Utils.SwapUInt16(BitConverter.ToUInt16(serializedMessage, 2));
+            var flagsBitfield = BinaryPrimitives.ReadUInt16BigEndian(new ReadOnlySpan<byte>(serializedMessage).Slice(2));
             var returnCode = (ReturnCode)(flagsBitfield & 0b0000_0000_0000_1111);
             Assert.Equal((ReturnCode)0b0000_0110, returnCode);
 


### PR DESCRIPTION
Improves parsing performance by quite a bit--the parse benchmark goes from about 750-800ns to 300ns on both .NET Core and .NET 4.6.1 platforms due to the heavy use of Span<T>/Memory<T>.